### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
       interval: "daily"
     labels:
       - "update"
+
+  # Update pip packages
+  - package-ecosystem: "pip"
+    directory: "{{cookiecutter.project_slug}}/"
+    schedule:
+      interval: "daily"

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,4 +1,4 @@
-pytz==2022.2.1  # https://github.com/stub42/pytz
+pytz==2022.5  # https://github.com/stub42/pytz
 python-slugify==6.1.2  # https://github.com/un33k/python-slugify
 Pillow==9.2.0  # https://github.com/python-pillow/Pillow
 {%- if cookiecutter.frontend_pipeline == 'Django Compressor' %}
@@ -29,7 +29,7 @@ uvicorn[standard]==0.18.3  # https://github.com/encode/uvicorn
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.2.15  # pyup: < 4.0  # https://www.djangoproject.com/
+django==4.0.8  # pyup: < 4.1  # https://www.djangoproject.com/
 django-environ==0.9.0  # https://github.com/joke2k/django-environ
 django-model-utils==4.2.0  # https://github.com/jazzband/django-model-utils
 django-allauth==0.51.0  # https://github.com/pennersr/django-allauth

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -18,7 +18,7 @@ watchfiles==0.17.0  # https://github.com/samuelcolvin/watchfiles
 
 # Testing
 # ------------------------------------------------------------------------------
-mypy==0.981  # https://github.com/python/mypy
+mypy==0.982  # https://github.com/python/mypy
 django-stubs==1.12.0  # https://github.com/typeddjango/django-stubs
 pytest==7.1.3  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.5  # https://github.com/Frozenball/pytest-sugar
@@ -28,7 +28,7 @@ djangorestframework-stubs==1.7.0  # https://github.com/typeddjango/djangorestfra
 
 # Documentation
 # ------------------------------------------------------------------------------
-sphinx==5.2.3  # https://github.com/sphinx-doc/sphinx
+sphinx==5.3.0  # https://github.com/sphinx-doc/sphinx
 sphinx-autobuild==2021.3.14 # https://github.com/GaretJax/sphinx-autobuild
 
 # Code quality
@@ -36,7 +36,7 @@ sphinx-autobuild==2021.3.14 # https://github.com/GaretJax/sphinx-autobuild
 flake8==5.0.4  # https://github.com/PyCQA/flake8
 flake8-isort==4.2.0  # https://github.com/gforcada/flake8-isort
 coverage==6.5.0  # https://github.com/nedbat/coveragepy
-black==22.8.0  # https://github.com/psf/black
+black==22.10.0  # https://github.com/psf/black
 pylint-django==2.5.3  # https://github.com/PyCQA/pylint-django
 {%- if cookiecutter.use_celery == 'y' %}
 pylint-celery==0.3  # https://github.com/PyCQA/pylint-celery

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -12,7 +12,7 @@ mysqlclient==2.1.0 # https://github.com/PyMySQL/mysqlclient
 Collectfast==2.2.0  # https://github.com/antonagestam/collectfast
 {%- endif %}
 {%- if cookiecutter.use_sentry == "y" %}
-sentry-sdk==1.9.9  # https://github.com/getsentry/sentry-python
+sentry-sdk==1.10.1  # https://github.com/getsentry/sentry-python
 {%- endif %}
 {%- if cookiecutter.use_docker == "n" and cookiecutter.windows == "y" %}
 hiredis==2.0.0  # https://github.com/redis/hiredis-py


### PR DESCRIPTION
Updating packages, including django, to modern equivalents. This is setup to match changes made in the original `cookiecutter-django` repo that has been updated to 4.0.

Also add `pip` to dependabot. Not sure if pyup is actively being used or not, but for me, dependabot seems like the better fit.